### PR TITLE
Port of the libo3d3xx ex-file_io example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ option(BUILD_TESTS "Build unit tests" ON)
 option(BUILD_MODULE_FRAMEGRABBER "Build the framegrabber module" ON)
 option(BUILD_MODULE_IMAGE "Build the image module" ON)
 option(BUILD_MODULE_TOOLS "Build the tools module" ON)
+option(BUILD_MODULE_EXAMPLES "Build the examples module" ON)
 option(BUILD_SDK_PKG "Build install packages for development purposes" ON)
 
 # Installation root
@@ -62,6 +63,9 @@ if(BUILD_MODULE_TOOLS)
   add_subdirectory(modules/tools)
 endif()
 
+if(BUILD_MODULE_EXAMPLES)
+  add_subdirectory(modules/examples)
+endif()
 #################################################
 # Packaging stuff - for now, we build debs only
 #################################################

--- a/modules/examples/CMakeLists.txt
+++ b/modules/examples/CMakeLists.txt
@@ -1,0 +1,69 @@
+project(IFM3D_EXAMPLES)
+cmake_minimum_required(VERSION 2.8.12)
+
+set(CMAKE_BUILD_TYPE Release) # Release or Debug
+
+set(CMAKE_MODULE_PATH
+    ${ifm3d_EXAMPLES_SOURCE_DIR}/../../cmake/modules
+    ${CMAKE_MODULE_PATH}
+    )
+
+# force an out-of-source build of the code
+include(MacroOutOfSourceBuild)
+macro_ensure_out_of_source_build(
+  "Please build ${PROJECT_NAME} out-of-source")
+
+################################################
+## Bring in dependent projects
+################################################
+include(ifm3d_version)
+find_package(PCL 1.7.1 REQUIRED COMPONENTS common io)
+find_package(OpenCV REQUIRED)
+find_package(Boost REQUIRED COMPONENTS system)
+
+find_library(LIB_boost_system NAMES boost_system)
+
+
+# Fix this: https://bugs.launchpad.net/ubuntu/+source/vtk6/+bug/1573234
+list(FIND PCL_IO_LIBRARIES "vtkproj4" VTKPROJ4_REQUIRED)
+if(NOT VTKPROJ4_REQUIRED EQUAL -1)
+    find_library(LIBVTKPROJ4_LIBRARY NAMES vtkproj4)
+    if(NOT ${LIBVTKPROJ4_LIBRARY})
+        list(REMOVE_ITEM PCL_IO_LIBRARIES "vtkproj4")
+    endif()
+endif()
+
+################################################
+## Manage our compiler and linker flags
+################################################
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+
+include_directories(
+  ${IFM3D_IMAGE_BINARY_DIR}/include
+  ${IFM3D_FG_BINARY_DIR}/include
+  ${IFM3D_CAMERA_BINARY_DIR}/include
+  ${PCL_INCLUDE_DIRS}
+  ${OpenCV_INCLUDE_DIRS}
+  )
+link_directories(
+  ${PCL_LIBRARY_DIRS}
+  ${OpenCV_LIBRARY_DIRS}
+  )
+add_definitions(
+  ${PCL_DEFINITIONS}
+  ${OpenCV_DEFINITIONS}
+  )
+
+################################################
+## Build the examples
+################################################
+
+add_executable(ex-file_io ex-file_io.cpp)
+target_link_libraries(ex-file_io
+                      ifm3d_image_shared
+                      ifm3d_framegrabber_shared
+                      ifm3d_camera_shared
+                      ${PCL_IO_LIBRARIES}
+                      ${OpenCV_LIBRARIES}
+                      )
+

--- a/modules/examples/README.md
+++ b/modules/examples/README.md
@@ -1,0 +1,43 @@
+
+ifm3d Examples
+==================
+
+This directory contains example programs that utilize `ifm3d`. The
+intention is to create standalone programs that illustrate one very specific
+concept in order to serve the purpose of letting developers ramp up quickly
+with using the library. The build infrastructure in this directory is minimal
+and the programs are intended to be run in place. Additonally, unless
+specifically stated otherwise, things like performance and robust error
+handling are not demonstrated. The purpose is to clearly illustrate the task
+without clouding it with the details of real-world software engineering --
+unless, of course, that was the point of the example.
+
+It is expected that this library of examples will grow over time in response to
+common themes we see on the issue tracker.
+
+Building the examples
+----------------------
+
+Assuming you are starting from the top-level directory of this source
+distribution:
+
+    $ mkdir build
+    $ cd build
+    $ cmake ..
+    $ make
+
+The example module is enabled by default. It can be excluded from the build by defining ``-DBUILD_MODULE_EXAMPLES=OFF``
+
+    $ mkdir build
+    $ cd build
+    $ cmake -DBUILD_MODULE_EXAMPLES=OFF ..
+    $ make
+
+
+What is included?
+-----------------
+
+* [ex-file_io](ex-file_io.cpp) Shows how to capture data from the camera and
+  write the images to disk. In this example, the amplitude and radial distance
+  image are written out as PNG files and the point cloud is written as a PCD.
+

--- a/modules/examples/ex-file_io.cpp
+++ b/modules/examples/ex-file_io.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2016 Love Park Robotics, LLC
+ * Copyright (C) 2017 ifm syntron gmbh
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distribted on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//
+// ex-file_io.cpp
+//
+// Capture a frame from the camera, and write the data out to files. For
+// exemplary purposes, we will write the amplitdue and radial distance images
+// to PNG files and the point cloud to a PCD file.
+//
+
+#include <iostream>
+#include <memory>
+#include <opencv2/opencv.hpp>
+#include <pcl/io/pcd_io.h>
+#include <pcl/point_cloud.h>
+#include <ifm3d/camera.h>
+#include <ifm3d/fg.h>
+#include <ifm3d/image.h>
+
+int main(int argc, const char **argv)
+{
+  auto cam = ifm3d::Camera::MakeShared();
+  auto fg = std::make_shared<ifm3d::FrameGrabber>(cam,(ifm3d::IMG_AMP|ifm3d::IMG_RDIS|ifm3d::IMG_CART));
+  auto img = std::make_shared<ifm3d::ImageBuffer>();
+  if (! fg->WaitForFrame(img.get(), 1000))
+    {
+      std::cerr << "Timeout waiting for camera!" << std::endl;
+      return -1;
+    }
+
+  pcl::io::savePCDFileASCII("point_cloud.pcd", *(img->Cloud()));
+  imwrite("amplitude.png", img->AmplitudeImage());
+  imwrite("radial_distance.png", img->DistanceImage());
+
+  return 0;
+}


### PR DESCRIPTION
This is a port of the ``libo3d3xx ex-fil_io`` example. Minor adjustments
are needed to work with the new ``ifm3d`` library. This is also a starting
point for porting the other examples from ``libo3d3xx``.

Signed-off-by: Christian Ege <christian.ege@ifm.com>