### PR TITLE
Fixed packaging on Linux

### DIFF
--- a/modules/camera/src/libifm3d_camera/CMakeLists.txt
+++ b/modules/camera/src/libifm3d_camera/CMakeLists.txt
@@ -5,20 +5,21 @@ else()
 	set(LIB_glog glog::glog)
 endif (NOT TARGET glog::glog)
 
+
 if(NOT WIN32)
     find_library(LIB_xmlrpcxx NAMES xmlrpc++)
     find_library(LIB_xmlrpc_clientxx NAMES xmlrpc_client++)
 else()
+  find_package(xmlrpc-c CONFIG REQUIRED COMPONENTS xmlrpc xmlrpc_client xmlrpc++ xmlrpc_client++)
 	set(LIB_xmlrpcxx
-		xmlrpc
-		xmlrpc_client
+    xmlrpc-c::xmlrpc
+		xmlrpc-c::xmlrpc_client
 	)
 	set(LIB_xmlrpc_clientxx
-		xmlrpc++
-		xmlrpc_client++
-	)
+    xmlrpc-c::xmlrpc++
+    xmlrpc-c::xmlrpc_client++
+  )
 endif(NOT WIN32)
-
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
@@ -46,6 +47,8 @@ if(WIN32)
 endif(WIN32)
 
 install(TARGETS ifm3d_camera_shared
-  DESTINATION lib
-  COMPONENT camera
+  RUNTIME DESTINATION ${_bin} COMPONENT camera
+  LIBRARY DESTINATION ${_lib} COMPONENT camera
+  ARCHIVE DESTINATION ${_lib} COMPONENT camera
+  PUBLIC_HEADER DESTINATION ${_include} COMPONENT camera
   )

--- a/modules/framegrabber/src/libifm3d_framegrabber/CMakeLists.txt
+++ b/modules/framegrabber/src/libifm3d_framegrabber/CMakeLists.txt
@@ -35,6 +35,8 @@ if(WIN32)
 endif(WIN32)
 
 install(TARGETS ifm3d_framegrabber_shared
-  DESTINATION lib
-  COMPONENT framegrabber
+  RUNTIME DESTINATION ${_bin} COMPONENT framegrabber
+  LIBRARY DESTINATION ${_lib} COMPONENT framegrabber
+  ARCHIVE DESTINATION ${_lib} COMPONENT framegrabber
+  PUBLIC_HEADER DESTINATION ${_include} COMPONENT framegrabber
   )

--- a/modules/image/src/libifm3d_image/CMakeLists.txt
+++ b/modules/image/src/libifm3d_image/CMakeLists.txt
@@ -34,6 +34,8 @@ if(WIN32)
 endif(WIN32)
 
 install(TARGETS ifm3d_image_shared
-  DESTINATION lib
-  COMPONENT image
+  RUNTIME DESTINATION ${_bin} COMPONENT image
+  LIBRARY DESTINATION ${_lib} COMPONENT image
+  ARCHIVE DESTINATION ${_lib} COMPONENT image
+  PUBLIC_HEADER DESTINATION ${_include} COMPONENT image
   )

--- a/modules/pcicclient/src/libifm3d_pcicclient/CMakeLists.txt
+++ b/modules/pcicclient/src/libifm3d_pcicclient/CMakeLists.txt
@@ -33,6 +33,8 @@ if(WIN32)
 endif(WIN32)
 
 install(TARGETS ifm3d_pcicclient_shared
-  DESTINATION lib
-  COMPONENT pcicclient
+  RUNTIME DESTINATION ${_bin} COMPONENT pcicclient
+  LIBRARY DESTINATION ${_lib} COMPONENT pcicclient
+  ARCHIVE DESTINATION ${_lib} COMPONENT pcicclient
+  PUBLIC_HEADER DESTINATION ${_include} COMPONENT pcicclient
   )

--- a/modules/tools/src/bin/CMakeLists.txt
+++ b/modules/tools/src/bin/CMakeLists.txt
@@ -3,6 +3,5 @@ target_link_libraries(ifm3d
   ifm3d_tools_shared
   )
 install(TARGETS ifm3d
-  DESTINATION bin
-  COMPONENT tools
+  DESTINATION ${_bin} COMPONENT tools
   )

--- a/modules/tools/src/libifm3d_tools/CMakeLists.txt
+++ b/modules/tools/src/libifm3d_tools/CMakeLists.txt
@@ -81,6 +81,8 @@ if(WIN32)
 endif(WIN32)
 
 install(TARGETS ifm3d_tools_shared
-  DESTINATION lib
-  COMPONENT tools
+  RUNTIME DESTINATION ${_bin} COMPONENT tools
+  LIBRARY DESTINATION ${_lib} COMPONENT tools
+  ARCHIVE DESTINATION ${_lib} COMPONENT tools
+  PUBLIC_HEADER DESTINATION ${_include} COMPONENT tools
   )


### PR DESCRIPTION
This builds packages on Linux and put the DLL into /bin and .lib into /lib folders on Windows. The hint how to solve this came from the [CMake mailinglist](https://cmake.org/pipermail/cmake/2012-October/052410.html). 

Signed-off-by: Christian Ege <christian.ege@ifm.com>