### PR TITLE
Perform a better semantic version check

### DIFF
--- a/modules/camera/src/libifm3d_camera/camera.cpp
+++ b/modules/camera/src/libifm3d_camera/camera.cpp
@@ -527,24 +527,43 @@ ifm3d::Camera::check_min_ifm_version(unsigned int major,
                                      unsigned int minor, unsigned int patch)
 {
 
-    auto data = this->pImpl->SWVersion();
-    const std::string swversion = data["IFM_Software"];
-    std::istringstream str(swversion);
-    std::vector<std::string> strings;
-    std::string token;
-    while (getline(str, token, '.'))
-      {
-        strings.push_back(token);
-      }
-    const auto cmajor = std::stoi(strings[0],nullptr);
-    const auto cminor = std::stoi(strings[1],nullptr);
-    const auto cpatch = std::stoi(strings[2],nullptr);
-    const auto res = (
-                (cmajor >= major) &&
-                (cminor >= minor) &&
-                (cpatch >= patch)
-               );
-    return res;
+  auto data = this->pImpl->SWVersion();
+  const std::string swversion = data["IFM_Software"];
+  std::istringstream str(swversion);
+  std::vector<std::string> strings;
+  std::string token;
+  while (getline(str, token, '.'))
+    {
+      strings.push_back(token);
+    }
+  const auto cmajor = std::stoi(strings[0],nullptr);
+  const auto cminor = std::stoi(strings[1],nullptr);
+  const auto cpatch = std::stoi(strings[2],nullptr);
+  auto res = false;
+  if(cmajor > major)
+    {
+      res = true;
+    }
+  else if (cmajor == major)
+    {
+      if(cminor > minor)
+        {
+          res = true;
+        }
+      else if (cminor == minor)
+        {
+          if(cpatch > patch)
+            {
+              res = true;
+            }
+          else if(cpatch == patch)
+            {
+              res = true;
+            }
+        }
+    }
+
+  return res;
 }
 
 json


### PR DESCRIPTION
This checks for any higher version than the given version triple.
The indentation was also fixed for this method.

Signed-off-by: Christian Ege <christian.ege@ifm.com>