### PR TITLE
Allow to import  JSON configurations from other cameras

### DIFF
--- a/modules/camera/src/libifm3d_camera/camera.cpp
+++ b/modules/camera/src/libifm3d_camera/camera.cpp
@@ -84,8 +84,9 @@ RO_LUT =
      }
     },
 
-    {"Apps",
+    {"App",
      {
+       {"Id", true},
      }
     },
 


### PR DESCRIPTION
The JSON configuration contains an entry ``Id`` for each application.
Which is used for internal tracking of the applications.

The error message when importing a configuration with an different ``App.Id``
is a bit misleading:

```
$ IFM3D_VLOG=30  ifm3d config  < config.json
ifm3d error: 101000
Sensor: The parameter name is invalid
```
This fixes issue #52 by adding the ``App.Id`` to the read only parameters

Signed-off-by: Christian Ege <christian.ege@ifm.com>