### PR TITLE
Removed boost regex and date_time dependency

### DIFF
--- a/modules/pcicclient/src/libifm3d_pcicclient/CMakeLists.txt
+++ b/modules/pcicclient/src/libifm3d_pcicclient/CMakeLists.txt
@@ -2,7 +2,7 @@
 ## Dependent projects
 ################################################
 find_package(Threads REQUIRED)
-find_package(Boost REQUIRED COMPONENTS system regex date_time)
+find_package(Boost REQUIRED COMPONENTS system)
 find_package(glog QUIET CONFIG NAMES google-glog glog)
 if(NOT TARGET glog::glog)
   find_library(LIB_glog NAMES glog)
@@ -51,8 +51,6 @@ target_link_libraries(
     ifm3d_camera_shared
     ${LIB_glog}
     Boost::system
-    Boost::regex
-    Boost::date_time
     Threads::Threads
   )
 


### PR DESCRIPTION
The dependency was removed in a previous commit.
The CMake build system was still requesting it. This will
completely remove the dependency for the PCIC client module.

Signed-off-by: Sachin Bangadkar <Sachin.Bangadkar@ifm.com>
Reviewed-by: Christian Ege <christian.ege@ifm.com>