### PR TITLE
Added lib gelog detection

### DIFF
--- a/cmake/modules/ifm3d-config.cmake.in
+++ b/cmake/modules/ifm3d-config.cmake.in
@@ -6,6 +6,9 @@ endif()
 option(FORCE_OPENCV3 "Force the build to require OpenCV 3" @FORCE_OPENCV3@)
 option(FORCE_OPENCV2 "Force the build to require OpenCV 2.4" @FORCE_OPENCV2@)
 
+# checking glog 
+find_package(glog QUIET CONFIG NAMES google-glog glog)
+
 if(NOT TARGET ifm3d::camera)
   set(ifm3d_FOUND False)
   message(FATAL_ERROR
@@ -16,10 +19,7 @@ else()
   foreach(_comp ${ifm3d_FIND_COMPONENTS})
     if(NOT "${_comp}" MATCHES "camera")
       if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/ifm3d-${_comp}-targets.cmake")
-        if("${_comp}" MATCHES "pcicclient")
-          # XXX: Remove this after pcic is implemented as PIMPL
-          find_package(Boost REQUIRED COMPONENTS system)
-        elseif("${_comp}" MATCHES "image")
+        if("${_comp}" MATCHES "image")
           if(FORCE_OPENCV3)
             find_package(OpenCV 3 REQUIRED COMPONENTS core)
           elseif(FORCE_OPENCV2)


### PR DESCRIPTION
The latest Google logging framework versions come with
CMake configuration support. This adds support for this
feature.

Signed-off-by: Sachin Bangadkar <Sachin.Bangadkar@ifm.com>
Reviewed-by: Christian Ege <christian.ege@ifm.com>