### PR TITLE
Added instructions how to switch between Release and Debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 cmake_policy(SET CMP0048 NEW)
 # Manage version number here: Major.Minor.Patch (we don't use "tweak")
-project(IFM3D VERSION 0.9.2 LANGUAGES CXX)
+project(IFM3D VERSION 0.9.3 LANGUAGES CXX)
 set(GIT_PROJECT_NAME "ifm3d")
 
 # Make our cmake functions accessible

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,8 @@
+## Changes between ifm3d 0.9.2 and 0.9.3
+
+* Added build instructions how to switch between Release and Debug
+  for Windows builds
+
 ## Changes between ifm3d 0.9.1 and 0.9.2
 
 * Added Support for the Ubuntu 18.04

--- a/doc/windows.md
+++ b/doc/windows.md
@@ -33,10 +33,10 @@ Make sure that you have installed CMake and Visual Studio 64bit before you move 
 
 Note: Visual Studio 2015 or later is required as older versions don't support all required features of C++11
 
-Note: Only x64 builds are suppported. 
+Note: Only x64 builds are suppported.
 
 The following command line examples assume we run from a windows command prompt with CMake and Git in the ``PATH`` variable.
-Depending on your installation you may have to add CMake and Git to your ``PATH`` variable. 
+Depending on your installation you may have to add CMake and Git to your ``PATH`` variable.
 
 First we need to set some variables, change these according to your installation.
 ```
@@ -46,6 +46,13 @@ set MSVC_MINOR_VERSION=1
 set IFM3D_BUILD_DIR=C:\ifm3d
 ```
 
+Setting the Configuration of the build
+```
+set CONFIG=Release
+```
+For other build change the CONFIG variable accordingly
+e.g.
+for Debug build  "set CONFIG=Debug"
 
 ## Getting the dependencies
 Create the work directory
@@ -68,7 +75,7 @@ cd %IFM3D_BUILD_DIR%\curl
 mkdir build
 cd build
 cmake -Ax64  -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON -DCMAKE_INSTALL_PREFIX=%IFM3D_BUILD_DIR%\install ..
-cmake --build . --clean-first --config Release --target INSTALL
+cmake --build . --clean-first --config %CONFIG% --target INSTALL
 ```
 
 ### [xmlrpc-c](http://xmlrpc-c.sourceforge.net/)
@@ -84,7 +91,7 @@ cd %IFM3D_BUILD_DIR%\xmlrpc-c
 mkdir build
 cd build
 cmake -Ax64  -DCMAKE_INSTALL_PREFIX=%IFM3D_BUILD_DIR%\install ..
-cmake --build . --clean-first --config Release --target INSTALL
+cmake --build . --clean-first --config %CONFIG% --target INSTALL
 ```
 
 ### [glog](https://github.com/google/glog)
@@ -100,7 +107,7 @@ cd %IFM3D_BUILD_DIR%\glog
 mkdir build
 cd build
 cmake -Ax64 -DCMAKE_INSTALL_PREFIX=%IFM3D_BUILD_DIR%\install ..
-cmake --build . --clean-first --config Release --target INSTALL
+cmake --build . --clean-first --config %CONFIG% --target INSTALL
 ```
 
 ### [FLANN](https://www.cs.ubc.ca/research/flann/)
@@ -116,7 +123,7 @@ cd %IFM3D_BUILD_DIR%\flann
 mkdir build
 cd build
 cmake -Ax64 -DBUILD_PYTHON_BINDINGS=OFF -DBUILD_MATLAB_BINDINGS=OFF  -DBUILD_EXAMPLES=OFF -DBUILD_TESTS=OFF -DBUILD_DOC=OFF -DCMAKE_INSTALL_PREFIX=%IFM3D_BUILD_DIR%\install ..
-cmake --build . --clean-first --config Release --target INSTALL
+cmake --build . --clean-first --config %CONFIG% --target INSTALL
 ```
 
 ### [Eigen](http://eigen.tuxfamily.org/index.php?title=Main_Page)
@@ -132,7 +139,7 @@ cd %IFM3D_BUILD_DIR%\eigen
 mkdir build
 cd build
 cmake -A x64 -DCMAKE_INSTALL_PREFIX=%IFM3D_BUILD_DIR%\install ..
-cmake --build . --clean-first --config Release --target INSTALL
+cmake --build . --clean-first --config %CONFIG% --target INSTALL
 ```
 
 ### [VTK](https://www.vtk.org/)
@@ -148,7 +155,7 @@ cd %IFM3D_BUILD_DIR%\vtk
 mkdir build
 cd build
 cmake -A x64 -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF -DCMAKE_INSTALL_PREFIX=%IFM3D_BUILD_DIR%\install ..
-cmake --build . --clean-first --config Release --target INSTALL
+cmake --build . --clean-first --config %CONFIG% --target INSTALL
 ```
 
 ### [PCL](http://pointclouds.org/)
@@ -164,7 +171,7 @@ cd %IFM3D_BUILD_DIR%\pcl
 mkdir build
 cd build
 cmake -A x64 DPCL_ENABLE_SSE=OFF -DWITH_CUDA=OFF -DWITH_DAVIDSDK=OFF -DWITH_DOCS=OFF -DWITH_DSSDK=OFF -DWITH_ENSENSO=OFF -DWITH_FZAPI=OFF -DWITH_LIBUSB=OFF -DWITH_OPENGL=ON -DWITH_OPENNI=OFF -DWITH_OPENNI2=OFF -DWITH_PCAP=OFF -DWITH_PNG=OFF -DWITH_QHULL=OFF -DWITH_QT=OFF -DWITH_RSSDK=OFF -DCMAKE_INSTALL_PREFIX=%IFM3D_BUILD_DIR%\install ..
-cmake --build . --clean-first --config Release --target INSTALL
+cmake --build . --clean-first --config %CONFIG% --target INSTALL
 ```
 
 ### [OpenCV](https://opencv.org/)
@@ -180,7 +187,7 @@ cd %IFM3D_BUILD_DIR%\opencv
 mkdir build_cmake
 cd build_cmake
 cmake -A x64 -DWITH_CUDA=OFF -DWITH_EIGEN=ON -DWITH_IPP=ON -DWITH_JASPTER=ON -DWITH_JPEG=ON -DWITH_OPENEXR=OFF -DWITH_OPENNI=OFF -DWITH_PNG=ON -DWITH_QT=OFF -DWITH_QT_OPENGL=OFF -DWITH_TBB=OFF -DWITH_TIFF=ON -DWITH_VIDEOINPUT=OFF -DBUILD_DOCS=OFF -DBUILD_EXAMPLES=OFF -DBUILD_PACKAGE=OFF -DBUILD_TESTS=OFF -DBUILD_PERF_TESTS=OFF -DBUILD_openvc_python=OFF -DCMAKE_PREFIX_PATH="%IFM3D_BUILD_DIR%\install"  -DCMAKE_INSTALL_PREFIX=%IFM3D_BUILD_DIR%\install ..
-cmake --build . --clean-first --config Release --target INSTALL
+cmake --build . --clean-first --config %CONFIG% --target INSTALL
 ```
 
 ## Building ifm3d
@@ -195,26 +202,26 @@ Build
 cd %IFM3D_BUILD_DIR%\ifm3d
 mkdir build
 cd build
-cmake -Ax64 -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON -DBUILD_SDK_PKG=ON -DBUILD_TESTS=OFF -DBUILD_MODULE_EXAMPLES=ON -DCMAKE_PREFIX_PATH="%IFM3D_BUILD_DIR%\install" -DBoost_INCLUDE_DIR="%BOOST_INSTALL_DIR%" -DBOOST_LIBRARYDIR="%BOOST_INSTALL_DIR%/lib64-msvc-%MSVC_MAJOR_VERSION%.%MSVC_MINOR_VERSION%" -DBoost_COMPILER=-vc%MSVC_MAJOR_VERSION%%MSVC_MINOR_VERSION% -DBoost_USE_STATIC_LIBS=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=%IFM3D_BUILD_DIR%\install ..
-cmake --build . --clean-first --config Release --target INSTALL
+cmake -Ax64 -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON -DBUILD_SDK_PKG=ON -DBUILD_TESTS=OFF -DCMAKE_PREFIX_PATH="%IFM3D_BUILD_DIR%\install" -DBoost_INCLUDE_DIR="%BOOST_INSTALL_DIR%" -DBOOST_LIBRARYDIR="%BOOST_INSTALL_DIR%/lib64-msvc-%MSVC_MAJOR_VERSION%.%MSVC_MINOR_VERSION%" -DBoost_COMPILER=-vc%MSVC_MAJOR_VERSION%%MSVC_MINOR_VERSION% -DBoost_USE_STATIC_LIBS=ON -DCMAKE_BUILD_TYPE=%CONFIG% -DCMAKE_INSTALL_PREFIX=%IFM3D_BUILD_DIR%\install ..
+cmake --build . --clean-first --config %CONFIG% --target INSTALL
 ```
 
 
 # Running ifm3d tool on Windows.
 After Building ifm3d, the binary files will be installed at ``%IFM3D_BUILD_DIR%\install\bin``. To run the ifm3d tool you need to add this directory to your path. You will also need to add the opencv and boost binary directories to your ``PATH``.
 
-For Visual Studio 2017 
+For Visual Studio 2017
 ```
 Set PATH=%IFM3D_BUILD_DIR%\install\bin;%IFM3D_BUILD_DIR%\install\x64\vc15\bin;C:\local\boost_1_64_0\lib64-msvc-%MSVC_MAJOR_VERSION%.%MSVC_MINOR_VERSION%;%PATH%
 ```
 
-For Visual Studio 2015 
+For Visual Studio 2015
 ```
 Set PATH=%IFM3D_BUILD_DIR%\install\bin;%IFM3D_BUILD_DIR%\install\x64\vc%MSVC_MAJOR_VERSION%\bin;C:\local\boost_1_64_0\lib64-msvc-%MSVC_MAJOR_VERSION%.%MSVC_MINOR_VERSION%;%PATH%
 ```
 
 After that you should be able to run the ifm3d tool
 ```
-ifm3d 
+ifm3d
 ```
 


### PR DESCRIPTION
This will fix issue #53 by building all third party libraries in Debug or Release mode to avoid linker errors.